### PR TITLE
Fix font display after latest commit

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@ import '@fontsource/vazirmatn/400.css'
 import '@fontsource/vazirmatn/500.css'
 import '@fontsource/vazirmatn/700.css'
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
 import './globals.css'
 import { UserProvider } from '@/context/userContext'
 import Header from '@/components/Header'
@@ -10,8 +9,6 @@ import Footer from '@/components/Footer'
 import { Toaster } from '@/components/ui/toaster'
 import ErrorBoundary from '@/app/components/ErrorBoundary'
 import BottomNav from '@/components/BottomNav'
-
-const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
   title: 'Muzikchi-موزیکچی',
@@ -30,7 +27,7 @@ interface RootLayoutProps {
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="fa" dir="rtl">
-      <body className={`${inter.className} font-vazir min-h-screen bg-gray-100`}>
+      <body className={`font-vazir min-h-screen bg-gray-100`}>
         <ErrorBoundary>
           <UserProvider>
             <Header />


### PR DESCRIPTION
Revert Inter font application to fix incorrect Vazirmatn font display.

A recent commit introduced the Inter font and applied it globally to the `<body>` element, which inadvertently overrode the intended Vazirmatn font styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ea8c453-31e4-4166-8db4-5cb886478983">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1ea8c453-31e4-4166-8db4-5cb886478983">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

